### PR TITLE
feat(nas): Add UE requested APN logging during default EPS bearer establishment

### DIFF
--- a/srsepc/hdr/mme/nas.h
+++ b/srsepc/hdr/mme/nas.h
@@ -277,6 +277,7 @@ private:
   uint16_t    m_mme_code  = 0;
   uint16_t    m_tac       = 0;
   std::string m_apn;
+  std::string m_ue_requested_apn;  // Store UE's requested APN from attach request
   std::string m_dns;
   std::string m_full_net_name;
   std::string m_short_net_name;

--- a/srsepc/src/mme/nas.cc
+++ b/srsepc/src/mme/nas.cc
@@ -912,6 +912,15 @@ bool nas::handle_attach_request(srsran::byte_buffer_t* nas_rx)
     return false;
   }
 
+  // Store UE's requested APN for later use during bearer establishment
+  if (pdn_con_req.apn_present || strlen(pdn_con_req.apn.apn) > 0) {
+    m_ue_requested_apn = pdn_con_req.apn.apn;
+    m_logger.info("UE requested APN: %s", m_ue_requested_apn.c_str());
+  } else {
+    m_ue_requested_apn = "(none)";
+    m_logger.info("UE requested APN: (none)");
+  }
+
   // Get UE IMSI
   if (attach_req.eps_mobile_id.type_of_id == LIBLTE_MME_EPS_MOBILE_ID_TYPE_IMSI) {
     for (int i = 0; i <= 14; i++) {
@@ -1616,6 +1625,12 @@ bool nas::pack_attach_accept(srsran::byte_buffer_t* nas_buffer)
   // set apn
   strncpy(act_def_eps_bearer_context_req.apn.apn, m_apn.c_str(), LIBLTE_STRING_LEN - 1);
   act_def_eps_bearer_context_req.proc_transaction_id = m_emm_ctx.procedure_transaction_id; // TODO
+
+  // Log both UE requested APN and configured APN being used
+  m_logger.info("Default EPS Bearer Context - UE requested APN: %s, Using configured APN: %s", 
+                m_ue_requested_apn.c_str(), m_apn.c_str());
+  srsran::console("Default EPS Bearer Context - UE requested APN: %s, Using configured APN: %s\n", 
+                  m_ue_requested_apn.c_str(), m_apn.c_str());
 
   // Set DNS server
   act_def_eps_bearer_context_req.protocol_cnfg_opts_present    = true;


### PR DESCRIPTION
## Summary

Adds visibility into UE's requested APN during default EPS bearer establishment by capturing the APN from the PDN Connectivity Request in the attach procedure and logging it alongside the configured APN being used.

## Changes

- **Enhanced NAS Context**: Added `m_ue_requested_apn` member variable to store UE's APN request
- **APN Capture**: Extract and store UE's requested APN during `handle_attach_request` processing
- **Comparative Logging**: Log both UE's requested APN and configured APN during bearer establishment
- **Debug Visibility**: Provide console and logger output for troubleshooting

## Problem Solved

Previously, when a UE attached to the network, the UE's requested APN was logged during initial processing but wasn't visible during actual default EPS bearer establishment. This made debugging APN-related issues difficult.

## Implementation Details

### 1. NAS Class Enhancement (`srsepc/hdr/mme/nas.h`)
```cpp
std::string m_ue_requested_apn;  // Store UE's requested APN from attach request
```

### 2. APN Request Capture (`srsepc/src/mme/nas.cc:915-922`)
```cpp
// Store UE's requested APN for later use during bearer establishment
if (pdn_con_req.apn_present || strlen(pdn_con_req.apn.apn) > 0) {
  m_ue_requested_apn = pdn_con_req.apn.apn;
  m_logger.info("UE requested APN: %s", m_ue_requested_apn.c_str());
} else {
  m_ue_requested_apn = "(none)";
  m_logger.info("UE requested APN: (none)");
}
```

### 3. Comparative APN Logging (`srsepc/src/mme/nas.cc:1629-1633`)
```cpp
// Log both UE requested APN and configured APN being used
m_logger.info("Default EPS Bearer Context - UE requested APN: %s, Using configured APN: %s", 
              m_ue_requested_apn.c_str(), m_apn.c_str());
srsran::console("Default EPS Bearer Context - UE requested APN: %s, Using configured APN: %s\n", 
                m_ue_requested_apn.c_str(), m_apn.c_str());
```

## Example Output

When a UE requests APN "internet" but EPC is configured with "srsapn":
```
UE requested APN: internet
Default EPS Bearer Context - UE requested APN: internet, Using configured APN: srsapn
```

## Test Plan

- [x] Code compiles successfully without errors or warnings
- [x] Maintains existing API compatibility and functionality  
- [x] Preserves all current logging and behavior
- [x] Added logging is informational only - no functional changes
- [ ] Runtime testing with UE attachments (manual verification recommended)

## Benefits

- **Enhanced Debugging**: Clear visibility into APN request vs configuration mismatches
- **Network Monitoring**: Better understanding of UE behavior and expectations  
- **Troubleshooting**: Improved diagnosis of connectivity and bearer establishment issues
- **Operational Insight**: Visibility into network usage patterns

Fixes #7

🤖 Generated with [Claude Code](https://claude.ai/code)