### PR TITLE
fix(ci): Remove non-existent libfftw3f-dev package from GitHub Actions

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -18,7 +18,6 @@ jobs:
           build-essential \
           cmake \
           libfftw3-dev \
-          libfftw3f-dev \
           libmbedtls-dev \
           libboost-program-options-dev \
           libconfig++-dev \
@@ -84,7 +83,6 @@ jobs:
             build-essential \
             cmake \
             libfftw3-dev \
-            libfftw3f-dev \
             libmbedtls-dev \
             libboost-program-options-dev \
             libconfig++-dev \


### PR DESCRIPTION
## Summary

Fix failing GitHub Actions builds by removing the non-existent `libfftw3f-dev` package from the CI workflow dependencies.

## Problem

All GitHub Actions workflows are currently failing with:
```
E: Unable to locate package libfftw3f-dev
Error: Process completed with exit code 100.
```

## Root Cause Analysis

The `libfftw3f-dev` package does not exist in modern Ubuntu repositories. The single-precision FFTW functionality is provided by the main `libfftw3-dev` package.

### Package Investigation
```bash
$ dpkg -L libfftw3-dev | grep -E "\.so$"
/usr/lib/x86_64-linux-gnu/libfftw3.so      # Double precision
/usr/lib/x86_64-linux-gnu/libfftw3f.so     # Single precision ✓
/usr/lib/x86_64-linux-gnu/libfftw3l.so     # Long precision
```

## Solution

Remove `libfftw3f-dev` from both build workflows:
- ✅ x86 Ubuntu builds (line 21)  
- ✅ aarch64 Ubuntu builds (line 87)

## Changes Made

### Before
```yaml
sudo apt install -y \
  libfftw3-dev \
  libfftw3f-dev \    # ← Non-existent package
  libmbedtls-dev \
```

### After
```yaml
sudo apt install -y \
  libfftw3-dev \     # ← Provides both single & double precision
  libmbedtls-dev \
```

## Verification

The `libfftw3-dev` package provides complete FFTW functionality:
- **Single precision**: `libfftw3f.so` + headers
- **Double precision**: `libfftw3.so` + headers  
- **Long precision**: `libfftw3l.so` + headers
- **All headers**: `/usr/include/fftw3.h`

## Impact

- 🟢 **Fixes**: All failing GitHub Actions workflows
- 🟢 **Maintains**: Full FFTW functionality (single + double precision)
- 🟢 **Supports**: Ubuntu 22.04 and 24.04 on x86_64 and aarch64
- 🟢 **No Breaking Changes**: Same FFTW libraries available to builds

## Test Plan

- [x] Identified root cause of CI failures
- [x] Verified `libfftw3-dev` provides single precision libraries
- [x] Updated both x86 and aarch64 workflows  
- [ ] GitHub Actions will test on push (automated)
- [ ] Verify successful builds on all matrix combinations

This fix restores the CI/CD pipeline functionality without any loss of build capabilities.

Fixes #11

🤖 Generated with [Claude Code](https://claude.ai/code)