### PR TITLE
Add AddressSanitizer and UndefinedBehaviorSanitizer support

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -116,3 +116,48 @@ jobs:
             cmake -DRF_FOUND=True -DENABLE_GUI=ON -GNinja ..
           fi
           ninja
+
+  sanitizer_build:
+    name: Build with Sanitizers
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build srsRAN with AddressSanitizer and UndefinedBehaviorSanitizer
+      run: |
+        sudo apt update
+        sudo apt install -y \
+          build-essential \
+          cmake \
+          libfftw3-dev \
+          libmbedtls-dev \
+          libboost-program-options-dev \
+          libconfig++-dev \
+          libsctp-dev \
+          libpcsclite-dev \
+          libdw-dev \
+          libzmq3-dev \
+          libboost-system-dev \
+          libboost-test-dev \
+          libboost-thread-dev \
+          qtbase5-dev \
+          libqwt-qt5-dev \
+          colordiff \
+          ninja-build \
+          valgrind
+        mkdir build && cd build
+        cmake \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g -Wno-maybe-uninitialized -Wno-stringop-overflow" \
+          -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g -Wno-maybe-uninitialized -Wno-stringop-overflow -Wno-deprecated-declarations" \
+          -DENABLE_UHD=OFF \
+          -DENABLE_BLADERF=OFF \
+          -DENABLE_SOAPYSDR=OFF \
+          -DENABLE_ZEROMQ=ON \
+          -DENABLE_WERROR=OFF \
+          -DENABLE_GUI=ON \
+          -GNinja \
+          ../
+        ninja
+        echo "=== Sanitizer Build Complete ==="
+        echo "Built binaries with AddressSanitizer and UndefinedBehaviorSanitizer"
+        echo "Runtime sanitizer output will be printed to console during execution"

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ progress.marks
 # Ignore temporary documentation files
 ISSUE_TEMPLATE.md
 PR_DESCRIPTION.md
+.serena/project.yml

--- a/build_srsran.sh
+++ b/build_srsran.sh
@@ -1,14 +1,41 @@
 #!/bin/bash
 
-# srsRAN 4G Build Script with Compatibility Handling
+# srsRAN 4G Build Script with Compatibility Handling and Sanitizer Support
 # For Ubuntu 25.04 with GCC 14.2 and Boost 1.83
 
 set -e
+
+# Default options
+ENABLE_SANITIZERS=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --sanitizers)
+            ENABLE_SANITIZERS=true
+            shift
+            ;;
+        --help|-h)
+            echo "Usage: $0 [--sanitizers] [--help]"
+            echo "  --sanitizers  Enable AddressSanitizer and UndefinedBehaviorSanitizer"
+            echo "  --help        Show this help message"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
 
 echo "=== srsRAN 4G Build Script ==="
 echo "System: $(lsb_release -d)"
 echo "Compiler: $(gcc --version | head -1)"
 echo "CMake: $(cmake --version | head -1)"
+if [ "$ENABLE_SANITIZERS" = true ]; then
+    echo "Sanitizers: AddressSanitizer + UndefinedBehaviorSanitizer ENABLED"
+fi
 echo
 
 # Check if we're in the right directory
@@ -23,26 +50,42 @@ rm -rf build
 mkdir build
 cd build
 
-# Configure with compatibility flags for GCC 14.2 and Boost 1.83
-echo "Configuring build with compatibility options..."
+# Configure build flags
+if [ "$ENABLE_SANITIZERS" = true ]; then
+    echo "Configuring build with sanitizers enabled..."
+    SANITIZER_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g"
+    BUILD_TYPE="Debug"
+    C_FLAGS="-Wno-maybe-uninitialized -Wno-stringop-overflow $SANITIZER_FLAGS"
+    CXX_FLAGS="-Wno-maybe-uninitialized -Wno-stringop-overflow -Wno-deprecated-declarations $SANITIZER_FLAGS"
+    echo "Sanitizer flags: $SANITIZER_FLAGS"
+else
+    echo "Configuring build with compatibility options..."
+    BUILD_TYPE="Release"
+    C_FLAGS="-Wno-maybe-uninitialized -Wno-stringop-overflow"
+    CXX_FLAGS="-Wno-maybe-uninitialized -Wno-stringop-overflow -Wno-deprecated-declarations"
+fi
+
 cmake \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_C_FLAGS="-Wno-maybe-uninitialized -Wno-stringop-overflow" \
-    -DCMAKE_CXX_FLAGS="-Wno-maybe-uninitialized -Wno-stringop-overflow -Wno-deprecated-declarations" \
-    -DENABLE_UHD=OFF \
-    -DENABLE_BLADERF=OFF \
-    -DENABLE_SOAPYSDR=OFF \
-    -DENABLE_ZEROMQ=ON \
+    -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+    -DCMAKE_C_FLAGS="$C_FLAGS" \
+    -DCMAKE_CXX_FLAGS="$CXX_FLAGS" \
     -DENABLE_WERROR=OFF \
     -DENABLE_GUI=ON \
     ../
 
 if [ $? -ne 0 ]; then
     echo "Configuration failed. Trying with more conservative settings..."
+    if [ "$ENABLE_SANITIZERS" = true ]; then
+        FALLBACK_C_FLAGS="-O1 -Wno-error $SANITIZER_FLAGS"
+        FALLBACK_CXX_FLAGS="-O1 -Wno-error $SANITIZER_FLAGS"
+    else
+        FALLBACK_C_FLAGS="-O1 -Wno-error"
+        FALLBACK_CXX_FLAGS="-O1 -Wno-error"
+    fi
     cmake \
         -DCMAKE_BUILD_TYPE=Debug \
-        -DCMAKE_C_FLAGS="-O1 -Wno-error" \
-        -DCMAKE_CXX_FLAGS="-O1 -Wno-error" \
+        -DCMAKE_C_FLAGS="$FALLBACK_C_FLAGS" \
+        -DCMAKE_CXX_FLAGS="$FALLBACK_CXX_FLAGS" \
         -DENABLE_UHD=OFF \
         -DENABLE_BLADERF=OFF \
         -DENABLE_SOAPYSDR=OFF \
@@ -72,6 +115,18 @@ if [ $? -eq 0 ]; then
     ls -la srsue/src/srsue 2>/dev/null && echo "  ✓ srsUE"
     ls -la srsenb/src/srsenb 2>/dev/null && echo "  ✓ srsENB"  
     ls -la srsepc/src/srsepc 2>/dev/null && echo "  ✓ srsEPC"
+    
+    if [ "$ENABLE_SANITIZERS" = true ]; then
+        echo
+        echo "=== Sanitizer Build Notes ==="
+        echo "AddressSanitizer and UndefinedBehaviorSanitizer are ENABLED"
+        echo "Runtime behavior:"
+        echo "  • Memory errors will be detected and reported to console"
+        echo "  • Undefined behavior will trigger runtime errors"
+        echo "  • Programs will run slower but provide detailed error reports"
+        echo "  • Set ASAN_OPTIONS='abort_on_error=1' to abort on first error"
+        echo "  • Set UBSAN_OPTIONS='print_stacktrace=1' for stack traces"
+    fi
     
     echo
     echo "Running basic tests..."

--- a/srsepc/src/mme/nas.cc
+++ b/srsepc/src/mme/nas.cc
@@ -1031,6 +1031,7 @@ bool nas::handle_pdn_connectivity_request(srsran::byte_buffer_t* nas_rx)
   if (nas_tx == nullptr) {
     srsran::console("Couldn't allocate PDU in %s().", __FUNCTION__);
     m_logger.error("Couldn't allocate PDU in %s().", __FUNCTION__);
+    return false;
   }
 
   LIBLTE_MME_PDN_CONNECTIVITY_REJECT_MSG_STRUCT pdn_con_reject = {};


### PR DESCRIPTION
## Summary

Implements comprehensive sanitizer support for both local development and CI/CD pipeline:

- **Local Development**: Enhanced build script with `--sanitizers` flag  
- **CI/CD Integration**: Dedicated GitHub Actions sanitizer build job
- **Runtime Detection**: Memory errors and undefined behavior caught at runtime
- **Developer Experience**: Clear documentation and environment variable guidance

## Technical Implementation

### Enhanced Local Build Script
```bash
./build_srsran.sh --sanitizers
```
- Applies `-fsanitize=address,undefined -fno-omit-frame-pointer -g` flags
- Forces Debug build type for optimal sanitizer performance
- Provides runtime behavior documentation and environment variable suggestions

### GitHub Actions Integration
- New `sanitizer_build` job running on Ubuntu 24.04
- Consistent sanitizer flags between local and CI builds
- Parallel execution with existing build jobs for comprehensive validation

### Runtime Behavior
**Sanitizer output DOES come to console at runtime:**
- AddressSanitizer: Immediate stderr output for memory errors (heap overflow, use-after-free, etc.)
- UndefinedBehaviorSanitizer: Runtime errors with detailed violation reports
- Configurable via `ASAN_OPTIONS` and `UBSAN_OPTIONS` environment variables

## Additional Improvements
- Minor bug fix in NAS PDN connectivity error handling (missing return false)
- Updated .gitignore for development configuration files

## Test plan
- [x] Local build with sanitizers configures correctly
- [x] CMake applies sanitizer flags properly (verified in CMakeCache.txt)
- [x] GitHub Actions workflow includes sanitizer build job
- [ ] CI sanitizer build completes successfully
- [ ] Runtime sanitizer detection works with test applications

Fixes #13

🤖 Generated with [Claude Code](https://claude.ai/code)